### PR TITLE
DE-1998 Tap-wrike-sdk - Add next page token and remove page limit

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -29,6 +29,9 @@ plugins:
           kind: password
         - name: start_date
           value: "2010-01-01T00:00:00Z"
+      select:
+        - tasks.*
+        - timelogs.*
   loaders:
     - name: target-jsonl
       variant: andyh1203

--- a/tap_wrike_sdk/client.py
+++ b/tap_wrike_sdk/client.py
@@ -33,7 +33,7 @@ class wrikeStream(RESTStream):
         return self.config["api_url"]
 
     records_jsonpath = "$[*]"  # Or override `parse_response`.
-    next_page_token_jsonpath = "$.next_page"  # Or override `get_next_page_token`.
+    next_page_token_jsonpath = "$.nextPageToken"  # Or override `get_next_page_token`.
 
     @cached_property
     def authenticator(self) -> _Auth:
@@ -110,10 +110,7 @@ class wrikeStream(RESTStream):
         """
         params: dict = {}
         if next_page_token:
-            params["page"] = next_page_token
-        if self.replication_key:
-            params["sort"] = "asc"
-            params["order_by"] = self.replication_key
+            params["nextPageToken"] = next_page_token
         return params
 
     def prepare_request_payload(

--- a/tap_wrike_sdk/streams.py
+++ b/tap_wrike_sdk/streams.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from singer_sdk import typing as th  # JSON Schema typing helpers
+from typing import Any, Dict, Optional
 
 from tap_wrike_sdk.client import wrikeStream
 
@@ -26,7 +26,7 @@ class TimelogsStream(wrikeStream):
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
-        params: dict = {}
+        params = super().get_url_params(context, next_page_token)
         params["fields"] = '[\"billingType\"]'
         return params
 
@@ -42,7 +42,7 @@ class TasksStream(wrikeStream):
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
-        params: dict = {}
+        params = super().get_url_params(context, next_page_token)
         params["fields"] = "[\"authorIds\",\"hasAttachments\",\"attachmentCount\",\"parentIds\",\"superParentIds\",\"sharedIds\",\"responsibleIds\",\"responsiblePlaceholderIds\",\"description\",\"briefDescription\",\"recurrent\",\"superTaskIds\",\"subTaskIds\",\"dependencyIds\",\"metadata\",\"customFields\",\"effortAllocation\",\"billingType\"]"
         params["pageSize"] = 1000
         return params


### PR DESCRIPTION
### Ticket ([DE-1998](https://potloc.atlassian.net/browse/DE-1998))

> We experienced a bug where we were only receiving a fraction of the information we should have been from the [https://github.com/potloc/tap-wrike-sdk](https://github.com/potloc/tap-wrike-sdk|smart-link). 
> 
> We can amend this by:
> - Implementing the json token path


---
_from `tiguidou` with :heart:_


[DE-1998]: https://potloc.atlassian.net/browse/DE-1998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ